### PR TITLE
Change remote add commands in the Pull Request Guide to use git over ssh

### DIFF
--- a/docs/How-To-Open-a-Homebrew-Pull-Request.md
+++ b/docs/How-To-Open-a-Homebrew-Pull-Request.md
@@ -27,7 +27,7 @@ The type of change you want to make influences which of Homebrew's main reposito
 3. Add your pushable forked repository as a new remote:
 
    ```sh
-   git remote add <YOUR_USERNAME> https://github.com/<YOUR_USERNAME>/brew.git
+   git remote add <YOUR_USERNAME> git@github.com:<YOUR_USERNAME>/brew.git
    ```
 
    * `<YOUR_USERNAME>` is your GitHub username, not your local machine username.
@@ -45,7 +45,7 @@ The type of change you want to make influences which of Homebrew's main reposito
 3. Add your pushable forked repository as a new remote:
 
    ```sh
-   git remote add <YOUR_USERNAME> https://github.com/<YOUR_USERNAME>/homebrew-core.git
+   git remote add <YOUR_USERNAME> git@github.com:<YOUR_USERNAME>/homebrew-core.git
    ```
 
    * `<YOUR_USERNAME>` is your GitHub username, not your local machine username.
@@ -63,7 +63,7 @@ The type of change you want to make influences which of Homebrew's main reposito
 3. Add your pushable forked repository as a new remote:
 
    ```sh
-   git remote add <YOUR_USERNAME> https://github.com/<YOUR_USERNAME>/homebrew-cask.git
+   git remote add <YOUR_USERNAME> git@github.com:<YOUR_USERNAME>/homebrew-cask.git
    ```
 
    * `<YOUR_USERNAME>` is your GitHub username, not your local machine username.


### PR DESCRIPTION
https pushes are no longer supported by github as of August 13, 2021

attempting to push over git https throws the below error

```
Username for 'https://github.com': sankalp-khare
Password for 'https://sankalp-khare@github.com':
remote: Support for password authentication was removed on August 13, 2021.
remote: Please see https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#cloning-with-https-urls for information on currently recommended modes of authentication.
fatal: Authentication failed for 'https://github.com/sankalp-khare/homebrew-core.git/'
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
